### PR TITLE
ci(lint): migrate golangci-lint to v2.12 and bump go.mod to 1.25.10

### DIFF
--- a/.github/workflows/sdk_integration_tests.yaml
+++ b/.github/workflows/sdk_integration_tests.yaml
@@ -117,17 +117,15 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12
           args: --timeout=5m ./tests/integration/...
           skip-cache: false
-          skip-pkg-cache: false
-          skip-build-cache: false
 
   test-summary:
     name: Test Summary

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/latitudesh/latitudesh-go-sdk
 
-go 1.22
+go 1.25.10
 
 require (
 	github.com/spyzhov/ajson v0.8.0

--- a/tests/integration/.golangci.yml
+++ b/tests/integration/.golangci.yml
@@ -1,68 +1,59 @@
 # golangci-lint configuration for integration tests
+version: "2"
 
 run:
-  timeout: 5m
   tests: true
-  skip-dirs:
-    - vendor
 
 linters:
   enable:
-    - gofmt
-    - goimports
-    - govet
     - errcheck
+    - govet
     - staticcheck
     - unused
-    - gosimple
     - ineffassign
-    - typecheck
     - misspell
     - unconvert
     - unparam
     - gocritic
     - gosec
+  settings:
+    govet:
+      enable-all: true
+    errcheck:
+      check-type-assertions: true
+      check-blank: false
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+      disabled-checks:
+        - commentFormatting
+        - whyNoLint
+    gosec:
+      excludes:
+        - G404 # Use of weak random number generator (acceptable in tests)
+  exclusions:
+    rules:
+      # Exclude some linters from running on tests files
+      - path: _test\.go
+        linters:
+          - gosec
+          - errcheck
+    paths:
+      - vendor
 
-linters-settings:
-  gofmt:
-    simplify: true
-
-  goimports:
-    local-prefixes: github.com/latitudesh/latitudesh-go-sdk
-
-  govet:
-    check-shadowing: true
-    enable-all: true
-
-  errcheck:
-    check-type-assertions: true
-    check-blank: false
-
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-    disabled-checks:
-      - commentFormatting
-      - whyNoLint
-
-  gosec:
-    excludes:
-      - G404 # Use of weak random number generator (acceptable in tests)
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/latitudesh/latitudesh-go-sdk
 
 issues:
-  exclude-rules:
-    # Exclude some linters from running on tests files
-    - path: _test\.go
-      linters:
-        - gosec
-        - errcheck
-
   max-same-issues: 0
   max-issues-per-linter: 0
-
-output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true


### PR DESCRIPTION
## Problem

The SDK now targets `go 1.25.10`, but the lint job pins `golangci/golangci-lint-action@v4` with `version: latest`, which resolves to golangci-lint **v1.64.8** (built with go1.24). A linter binary built with go1.24 cannot analyze a go1.25 module, so the job fails at config load:

```
can't load config: the Go language version (go1.24) used to build golangci-lint
is lower than the targeted Go version (1.25.10)
```

This breaks lint on every SDK regeneration that carries the `go 1.25.10` directive.

## Why "just pin a version" isn't enough

- No golangci-lint **v1.x** release is built with go ≥ 1.25 — only **v2.x** binaries are. So the linter must move to v2.
- The `--go=1.24` analysis override doesn't help: a go1.24 binary still fails typecheck on go1.25 packages (`package requires newer Go version go1.25`).
- golangci-lint v2 rejects the existing v1 `tests/integration/.golangci.yml` (`unsupported version of the configuration`), so the config must be migrated.
- `golangci-lint-action@v4` doesn't support golangci-lint v2, so the action must be bumped.

## Changes

- **`go.mod`**: `go 1.22` → `go 1.25.10` (aligns the committed directive with what the generated SDK targets).
- **`tests/integration/.golangci.yml`**: migrated to golangci-lint v2 format (`version: "2"`, `gofmt`/`goimports` moved to `formatters`, `gosimple` folded into `staticcheck`, `skip-dirs`/`exclude-rules` → `exclusions`, dropped removed keys `govet.check-shadowing` / `output.format` / `typecheck`).
- **`.github/workflows/sdk_integration_tests.yaml`** (lint job): `golangci-lint-action@v4` → `@v9`, `version: latest` → `v2.12`, `setup-go` → `go-version-file: go.mod`, and dropped the removed `skip-pkg-cache` / `skip-build-cache` inputs.

## Verification

Reproduced locally against the `go 1.25.10` module using the exact CI invocation (from repo root):

- `golangci-lint v1.64.8` → reproduces the failure.
- `golangci-lint v2.12.2` (built with go1.26.2) + migrated config → `config verify` clean, `golangci-lint run --timeout=5m ./tests/integration/...` returns **0 issues**.
- `go build ./...` and `go vet ./tests/integration/...` pass.

The integration-tests + lint jobs run on this PR (it touches `go.mod` and `tests/integration/**`), exercising the fix against `go 1.25.10`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Go version directive, lint config, and CI workflow; no SDK runtime or API behavior is modified.
> 
> **Overview**
> Fixes CI lint failures when the module targets **Go 1.25.10** by aligning the toolchain and **golangci-lint v2**.
> 
> **`go.mod`** bumps the `go` directive from **1.22** to **1.25.10** so it matches the generated SDK target.
> 
> **`tests/integration/.golangci.yml`** is migrated to golangci-lint **v2** (`version: "2"`): formatters (`gofmt`/`goimports`) are split out, `gosimple` is dropped in favor of `staticcheck`, and v1-only keys (`skip-dirs`, `exclude-rules`, `linters-settings`, etc.) are replaced with v2 `exclusions` / nested `settings`. Test-file and `vendor` exclusions are preserved.
> 
> The **lint** job in **`sdk_integration_tests.yaml`** uses **`setup-go`** with **`go-version-file: go.mod`**, pins **`golangci-lint-action@v9`** and linter **`v2.12`** (instead of v4 + `latest`), and removes deprecated action inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61514c7e45ced07f32fa3b55f98d542b5adb9c2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->