### PR TITLE
fix(tests): read object storage access_key from credentials object

### DIFF
--- a/tests/integration/helpers/mock_data.go
+++ b/tests/integration/helpers/mock_data.go
@@ -345,7 +345,9 @@ func MockObjectStorage() map[string]interface{} {
 			"size_in_gb":  0,
 			"bucket_name": "my-bucket-abc123",
 			"endpoint":    "https://s3.dal.latitude.sh",
-			"access_key":  "AKIAEXAMPLE1234567890",
+			"credentials": map[string]interface{}{
+				"access_key": "AKIAEXAMPLE1234567890",
+			},
 			"region": map[string]interface{}{
 				"id":      "DAL",
 				"city":    "Dallas",

--- a/tests/integration/objectstorage_test.go
+++ b/tests/integration/objectstorage_test.go
@@ -76,7 +76,8 @@ func TestObjectStorageIntegration(t *testing.T) {
 			bucket := result.ObjectStorages.Data[0]
 			assert.Equal(t, "my-bucket-abc123", *bucket.Attributes.BucketName)
 			assert.Equal(t, "https://s3.dal.latitude.sh", *bucket.Attributes.Endpoint)
-			assert.Equal(t, "AKIAEXAMPLE1234567890", *bucket.Attributes.AccessKey)
+			require.NotNil(t, bucket.Attributes.Credentials)
+			assert.Equal(t, "AKIAEXAMPLE1234567890", *bucket.Attributes.Credentials.AccessKey)
 			require.NotNil(t, bucket.Attributes.Region)
 			assert.Equal(t, "DAL", *bucket.Attributes.Region.ID)
 		})

--- a/tests/integration/objectstorage_test.go
+++ b/tests/integration/objectstorage_test.go
@@ -76,8 +76,8 @@ func TestObjectStorageIntegration(t *testing.T) {
 			bucket := result.ObjectStorages.Data[0]
 			assert.Equal(t, "my-bucket-abc123", *bucket.Attributes.BucketName)
 			assert.Equal(t, "https://s3.dal.latitude.sh", *bucket.Attributes.Endpoint)
-			require.NotNil(t, bucket.Attributes.Credentials)
-			assert.Equal(t, "AKIAEXAMPLE1234567890", *bucket.Attributes.Credentials.AccessKey)
+			// S3 credentials are only returned for extra_fields[object_storages]=credentials
+			// requests made by the bucket's creator, so they are not asserted here.
 			require.NotNil(t, bucket.Attributes.Region)
 			assert.Equal(t, "DAL", *bucket.Attributes.Region.ID)
 		})


### PR DESCRIPTION
## Problem

SDK generation fails on the `Compile Tests` step for the Go target:

```
tests/integration/objectstorage_test.go:79:64: bucket.Attributes.AccessKey undefined
  (type *components.ObjectStorageDataAttributes has no field or method AccessKey)
```

This is not a generator issue — Speakeasy retried with the previous known-good version (1.792.0 → 1.791.1) and failed identically.

The OpenAPI spec changed: `access_key` moved out of `object_storage_data.attributes` into a new nested `credentials` object.

```
components/schemas/object_storage_data/properties/attributes/properties/credentials/properties/access_key
```

The regenerated model exposes `Attributes.Credentials.AccessKey`, but the hand-written integration test (which the generator does not touch) still read `Attributes.AccessKey`. `go build ./...` passes; `go test` fails to compile, which aborts generation.

## Why the assertion is removed rather than moved

The two CI workflows compile this test against different models, which makes any reference to the field a deadlock:

- **Integration Tests** (this PR) compiles against the models committed on the branch — the old shape, which has `AccessKey` but no `Credentials`.
- **Generate** regenerates the models from the live spec first, then compiles — the new shape, which has `Credentials` but no `AccessKey`.

So `AccessKey` breaks generation and `Credentials` breaks the PR checks. Referencing neither is the only form that compiles under both.

Dropping the assertion is also correct on its own terms: `credentials` is now returned only when `extra_fields[object_storages]=credentials` is requested *and* the caller created the bucket. This test mocks a plain `GET /storage/buckets`, where the field would not be present in a real response.

## Changes

- `tests/integration/objectstorage_test.go` — remove the `access_key` assertion, with a comment explaining the field is conditional.
- `tests/integration/helpers/mock_data.go` — nest `access_key` under `credentials` in the mock payload, matching the current spec.

The remaining assertions (`bucket_name`, `endpoint`, `region`) are unchanged.

## Verification

Built and tested against **both** model shapes — the committed one and a local copy patched to the shape the generator will emit (`Credentials` as a plain pointer, mirroring `Region`, which has the identical shape in the spec: nullable object, not required):

```
old model shape:  go build ./...  OK   go test ./tests/...  ok  0.533s
new model shape:  go build ./...  OK   go test ./tests/...  ok  0.484s
```

`go vet ./tests/...` and `gofmt -l tests/` are clean.

## Follow-up

Once the regenerated models land on `main`, the assertion can be restored as `bucket.Attributes.Credentials.AccessKey` in a separate PR if the coverage is wanted.

## Note for the API side

Two related spec changes worth confirming as intentional, since both are breaking for SDK consumers:

- `secret_key` was dropped from the bucket attributes entirely (it now only appears in the `POST /storage/access_keys` response).
- `access_key` is now conditional, as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and mock-only changes with no production SDK logic modified; low risk aside from ensuring future model regeneration matches the nested credentials shape.
> 
> **Overview**
> Updates object storage integration fixtures and tests so they match the **OpenAPI shape** where S3 `access_key` lives under **`attributes.credentials`**, not as a top-level attribute.
> 
> In **`mock_data.go`**, the mock bucket JSON nests `access_key` inside `credentials`. In **`objectstorage_test.go`**, the list-buckets case no longer asserts `Attributes.AccessKey` (that field will disappear from generated models); it keeps checks for bucket name, endpoint, and region, with a short note that credentials are only returned for `extra_fields[object_storages]=credentials` when the caller created the bucket.
> 
> This unblocks **`go test`** / SDK **Compile Tests** once models are regenerated for the spec change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe52879bf6c6641264517725ef7ee8afda05401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->