### PR TITLE
feat(ci): trigger Mintlify docs update after SDK publish

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,6 +60,22 @@ Workflow to publish the SDK when there are changes.
 - Push to `main` when `.speakeasy/gen.lock` changes
 - Manual dispatch
 
+### 4. Update Docs (`docs_update.yaml`)
+
+Triggers a Mintlify docs deployment after a successful SDK publish, so the API
+reference (which pulls the Speakeasy spec with code samples at build time)
+reflects the newly released SDK without waiting for an unrelated docs push.
+
+**Triggers:**
+- Completion of the `Publish` workflow (only proceeds on success)
+- Manual dispatch
+
+**Configuration:**
+- Requires the `MINTLIFY_PROJECT_ID` repository variable
+- Requires the `MINTLIFY_ADMIN_API_KEY` secret
+
+Both values come from the Mintlify dashboard (Settings → API keys).
+
 ## Secret Configuration
 
 The following secrets must be configured in the repository:
@@ -68,6 +84,13 @@ The following secrets must be configured in the repository:
 |--------|-------------|---------|
 | `GITHUB_TOKEN` | Automatic GitHub token | All workflows |
 | `SPEAKEASY_API_KEY` | Speakeasy API key | SDK Generation, SDK Publish |
+| `MINTLIFY_ADMIN_API_KEY` | Mintlify admin API key | Update Docs |
+
+The following repository variables must be configured:
+
+| Variable | Description | Used by |
+|----------|-------------|---------|
+| `MINTLIFY_PROJECT_ID` | Mintlify project ID | Update Docs |
 
 ## Permissions
 

--- a/.github/workflows/docs_update.yaml
+++ b/.github/workflows/docs_update.yaml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - name: Trigger Mintlify deployment
         run: |
-          curl -sS --fail-with-body --retry 3 -X POST \
+          curl -sS --fail-with-body -X POST \
             "https://api.mintlify.com/v1/project/update/${{ vars.MINTLIFY_PROJECT_ID }}" \
             -H "Authorization: Bearer ${{ secrets.MINTLIFY_ADMIN_API_KEY }}"

--- a/.github/workflows/docs_update.yaml
+++ b/.github/workflows/docs_update.yaml
@@ -1,0 +1,19 @@
+name: Update Docs
+permissions: {}
+"on":
+  workflow_run:
+    workflows:
+      - Publish
+    types:
+      - completed
+  workflow_dispatch: {}
+jobs:
+  trigger-mintlify:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Mintlify deployment
+        run: |
+          curl -sS --fail-with-body --retry 3 --retry-all-errors -X POST \
+            "https://api.mintlify.com/v1/project/update/${{ vars.MINTLIFY_PROJECT_ID }}" \
+            -H "Authorization: Bearer ${{ secrets.MINTLIFY_ADMIN_API_KEY }}"

--- a/.github/workflows/docs_update.yaml
+++ b/.github/workflows/docs_update.yaml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - name: Trigger Mintlify deployment
         run: |
-          curl -sS --fail-with-body --retry 3 --retry-all-errors -X POST \
+          curl -sS --fail-with-body --retry 3 -X POST \
             "https://api.mintlify.com/v1/project/update/${{ vars.MINTLIFY_PROJECT_ID }}" \
             -H "Authorization: Bearer ${{ secrets.MINTLIFY_ADMIN_API_KEY }}"


### PR DESCRIPTION
### Summary

The docs API reference pulls the Speakeasy spec (with code samples) at Mintlify build time, but Mintlify only rebuilds when the docs monorepo default branch receives a push — so SDK releases leave the Endpoints section stale until an unrelated docs change lands.

This adds an `Update Docs` workflow that fires after a successful `Publish` run (i.e., whenever a new SDK version ships) and calls Mintlify's [trigger-update endpoint](https://www.mintlify.com/docs/api/update/trigger) to rebuild the docs. It can also be run manually via workflow dispatch.

Requires:
- `MINTLIFY_PROJECT_ID` repository variable
- `MINTLIFY_ADMIN_API_KEY` repository secret

Both values come from the Mintlify dashboard (Settings → API keys).

### Testing

1. Set the repository variable and secret:
   ```bash
   gh variable set MINTLIFY_PROJECT_ID --repo latitudesh/latitudesh-go-sdk --body "<project-id>"
   gh secret set MINTLIFY_ADMIN_API_KEY --repo latitudesh/latitudesh-go-sdk
   ```
2. After merge, run the workflow manually and check for a 202 response with a `statusId` in the logs:
   ```bash
   gh workflow run "Update Docs" --repo latitudesh/latitudesh-go-sdk
   ```
3. Confirm a new deployment appears in the Mintlify dashboard, then verify end-to-end on the next Speakeasy regen merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that calls an external docs API with repository secrets; no application or SDK runtime behavior is modified.
> 
> **Overview**
> Adds an **Update Docs** GitHub Actions workflow so Mintlify rebuilds right after a successful **Publish** run, keeping the API reference (Speakeasy spec + samples) in sync with new SDK releases instead of waiting for an unrelated docs push.
> 
> The workflow uses `workflow_run` on completed **Publish** (guarded to `success` only) or manual `workflow_dispatch`, and POSTs to Mintlify’s project update API using `MINTLIFY_PROJECT_ID` and `MINTLIFY_ADMIN_API_KEY`. Workflow docs in `.github/workflows/README.md` describe triggers, configuration, and the new secret/variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d3107e70233db5caff52dab7f96c717dd0f2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a GitHub Actions workflow that triggers a Mintlify documentation rebuild after a successful SDK publish or manual dispatch.
- Calls Mintlify’s project-update endpoint using a repository variable and secret.
- Documents the workflow’s triggers and required configuration.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["Update .github/workflows/docs\_update.yam..."](https://github.com/latitudesh/latitudesh-go-sdk/commit/f5d3107e70233db5caff52dab7f96c717dd0f2b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56678324)</sub>

<!-- /greptile_comment -->